### PR TITLE
feat: add bodies plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: "Deploy"
 
 on:
   push:
-  pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "rust-lang.rust-analyzer",
     "tamasfe.even-better-toml",
-    "svelte.svelte-vscode"
+    "svelte.svelte-vscode",
+    "github.vscode-github-actions"
   ]
 }

--- a/simulation/src/main.rs
+++ b/simulation/src/main.rs
@@ -1,6 +1,7 @@
-use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
+mod render_body_plugin;
+
 use bevy::prelude::*;
-use iyes_perf_ui::prelude::*;
+use render_body_plugin::RenderBodiesPlugin;
 
 fn main() {
   #[cfg(not(target_arch = "wasm32"))]
@@ -25,22 +26,6 @@ fn main() {
 
   App::new()
     .add_plugins(plugins)
-    .add_plugins(FrameTimeDiagnosticsPlugin)
-    .add_plugins(PerfUiPlugin)
-    .add_systems(Startup, setup)
+    .add_plugins(RenderBodiesPlugin)
     .run();
-}
-
-fn setup(mut commands: Commands) {
-  commands.spawn(Camera2dBundle::default());
-
-  commands.spawn((
-    PerfUiRoot {
-      display_labels: false,
-      layout_horizontal: true,
-      ..default()
-    },
-    PerfUiEntryFPSWorst::default(),
-    PerfUiEntryFPS::default(),
-  ));
 }

--- a/simulation/src/render_body_plugin.rs
+++ b/simulation/src/render_body_plugin.rs
@@ -1,0 +1,62 @@
+use bevy::{prelude::*, sprite::*};
+
+#[derive(Component)]
+pub struct Body;
+
+#[derive(Component)]
+pub struct Mass(i32);
+
+#[derive(Component)]
+pub struct Speed(f32);
+
+pub struct RenderBodiesPlugin;
+
+impl Plugin for RenderBodiesPlugin {
+  fn build(&self, app: &mut App) {
+    app
+      .add_systems(Startup, setup)
+      .add_systems(Startup, add_bodies)
+      .add_systems(Update, attract_bodies);
+  }
+}
+
+fn setup(mut commands: Commands) {
+  commands.spawn(Camera2dBundle::default());
+}
+
+fn add_bodies(
+  mut commands: Commands,
+  mut meshes: ResMut<Assets<Mesh>>,
+  mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+  let shapes = [
+    Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
+    Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
+    Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
+  ];
+
+  let color = Color::hsl(200., 0.95, 0.7);
+
+  for (index, shape) in shapes.into_iter().enumerate() {
+    commands.spawn((
+      Body,
+      Mass(10),
+      Speed(10.0),
+      MaterialMesh2dBundle {
+        mesh: shape,
+        material: materials.add(color),
+        transform: Transform::from_xyz(100.0 * index as f32 - 100.0, 0.0, 0.0),
+        ..default()
+      },
+    ));
+  }
+}
+
+// TODO: Correct formula
+fn attract_bodies(time: Res<Time>, mut query: Query<(&mut Transform, &Speed, &Mass), With<Body>>) {
+  for (mut transform, speed, mass) in query.iter_mut() {
+    transform.translation.x -= 10.0 * time.delta_seconds() * speed.0;
+    transform.translation.y -= 10.0 * time.delta_seconds() * speed.0;
+    dbg!(mass.0);
+  }
+}

--- a/simulation/src/render_body_plugin.rs
+++ b/simulation/src/render_body_plugin.rs
@@ -40,8 +40,8 @@ fn add_bodies(
   for (index, shape) in shapes.into_iter().enumerate() {
     commands.spawn((
       Body,
-      Mass(10),
-      Speed(10.0),
+      Mass(10),    // TODO: configurable
+      Speed(10.0), // TODO: Set to 0.0
       MaterialMesh2dBundle {
         mesh: shape,
         material: materials.add(color),


### PR DESCRIPTION
This adds a `RenderBodyPlugin` that adds a 2d Camera and three bodies (Circle shapes).

It also adds a System that will (for now) continuosly move the shapes bottom on the screen.

Closes #1 